### PR TITLE
Support for .mts extension

### DIFF
--- a/src/ts-inquisition.ts
+++ b/src/ts-inquisition.ts
@@ -34,7 +34,7 @@ export async function runGlobAndModifyTsFiles(
   folder: string,
   breadcrumbDate = true
 ) {
-  const globPath = path.join(process.cwd(), `${folder}/*.{ts,tsx}`)
+  const globPath = path.join(process.cwd(), `${folder}/*.{ts,tsx,mts,mtsx}`)
   console.log('runGlobAndModifyTsFiles -> globPath', globPath)
   const files = await globby([globPath])
 


### PR DESCRIPTION
- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

- **What is the current behavior?** (You can also link to an open issue here)

Tool fails (noop) on projects set with `.mts` extensions (for me that happened on https://github.com/SBoudrias/Inquirer.js)

- **What is the new behavior (if this is a feature change)?**

Now the glob should cover all valid ts extensions 😄 